### PR TITLE
Enhanced footnote reference and marker styling

### DIFF
--- a/packages/styles.lua
+++ b/packages/styles.lua
@@ -378,6 +378,7 @@ elements being optional):
 \\style:define[name=\doc:args{name}]\{
 \par\quad\\font[\doc:args{font specification}]
 \par\quad\\color[color=\doc:args{color}]
+\par\quad\\properties[position=\doc:args{normal|super|sub}]
 \par\}
 \end{doc:codes}
 
@@ -393,6 +394,9 @@ specifications are not (necessarily) corresponding to actual commands.
 It just uses that familiar syntax as a convenience.\footnote{Technically-minded readers may
 also note it is also very simple to implement that way, just relying
 on SILE’s standard parser and its underlying AST.}
+
+Additional user-defined positioning properties can be registered by name and
+command in \doc:code{SILE.scratch.styles.positions}.
 
 A style can also inherit from a previously-defined style:
 
@@ -492,6 +496,22 @@ It obviously requires the font to have these characters, and due to the way how 
 done, the enumeration to stay within a range corresponding to expected characters.
 
 The other character formatting commands should of course apply to the full label.
+
+\P{Character styles for footnote markers.}
+
+As for other styles above, the character style for foonoter markers (i.e. the footnote
+symbol or counter in the note itself) should support the "numbering" specification.
+
+\begin{doc:codes}
+\quad{}\\numbering[before=\doc:args{string}, after=\doc:args{string}, kern=\doc:args{length}]
+\end{doc:codes}
+
+For consistency, footnote references (i.e. the footnote call in the main text body) should support
+at least the first properties, that is:
+
+\begin{doc:codes}
+\quad{}\\numbering[before=\doc:args{string}, after=\doc:args{string}]
+\end{doc:codes}
 
 \P{Paragraph styles.}
 


### PR DESCRIPTION
The `omifootnotes` package typesets the footnote reference (call in the text body) and marker (counter in the footnote) as superscripts. The later is followed by a fixed non-breaking inter-word kern.

Provide more control to the user via styles, so that it's no longer hard-coded and the user can easily style these things at convenience (font, color, position, spacing, etc.).

Proposed changes to the `omifootnote` package:
- `footnote-reference` style for the footnote call reference
- `footnote-marker` style for the footnote marker
- `footnote-reference-mark`, `footnote-reference-counter`, `footnote-marker-mark`, `footnote-marker-counter` derived styles, for specific distinct customization of each of them (i.e. custom mark vs. automatic numbering) if need be.
- These styles should support the `\numbering[before=<string>, after=<string>, kern=<length>` style specification

Proposed change to the `styles` package:
- Support for another generic style specification `\properties[position=<normal|super|sub>`] so the we can use the super version by default for footnotes.

Example objectives
![image](https://user-images.githubusercontent.com/18075640/172023331-54202aaa-29da-41ba-808f-3cde7c1667ce.png)
